### PR TITLE
Add hotkey unregister functionality and prevent duplicate listeners on app restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ app.whenReady().then(() => {
 This project is early in development and I have lots of ideas to expand the capabilities. Here's a roadmap of planned additions to qHotkeys.
 
 - Add event info to the action callbacks
-- Ability to unregister a hotkey
 - Individual scroll registers
 - Add mouse buttons
 - Add mouse move

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qhotkeys",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "Electron global shortcut registrar that doesn't override pre-existing shortcuts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "author": "QarthO <qartho@gmail.com> (quartzdev.gg)",
   "license": "MIT",
   "dependencies": {
-    "uiohook-napi": "^1.5.0"
+    "uiohook-napi": "^1.5.4"
   },
   "devDependencies": {
-    "@types/node": "^20.3.1",
-    "typescript": "^5.1.3"
+    "@types/node": "^20.12.12",
+    "typescript": "^5.4.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,10 @@ export class qHotkeys {
     this.hotkey_map.set(keys, action)
   }
 
+  public unregisterAll = (): void => {
+    this.hotkey_map.clear()
+  }
+
   public registerScroll = (keys: number[], upAction: () => void, downAction: () => void): void => {
     this.scroll_hotkey_map.set(keys, [upAction, downAction])
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,16 @@ export class qHotkeys {
     this.hotkey_map.clear()
   }
 
+  public unregister = (keys: number[]): void => {
+    // remove keys from the map
+    this.hotkey_map.forEach((_, hotkeys: number[]) => {
+      if (hotkeys.every((key) => keys.includes(key)) && hotkeys.length == keys.length) {
+        if (this.debug) console.log(`Unregistered: ${hotkeys.join(' + ')}`)
+        this.hotkey_map.delete(hotkeys)
+      }
+    })
+  }
+
   public registerScroll = (keys: number[], upAction: () => void, downAction: () => void): void => {
     this.scroll_hotkey_map.set(keys, [upAction, downAction])
   }


### PR DESCRIPTION
In this pull request, we introduce two key enhancements to the hotkey functionality.

Firstly, we add the ability to unregister a hotkey, providing more flexibility in managing hotkey assignments.
Secondly, when stop is called, we remove the listeners. This prevents the creation of duplicate listeners when the app is restarted as long as stop is called.