### PR TITLE
feat: add github actions to auto-publish to npmjs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: Build and Release QHotkeys
+
+on:
+  push:
+    branches:
+      - main  # Set this to the branch you want to build from
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  # Specifies that the job should run on the latest Ubuntu runner
+
+    steps:
+      - uses: actions/checkout@v4  # Checks out your repository under $GITHUB_WORKSPACE
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 'latest'
+
+      - name: Install dependencies with Bun
+        run: bun install
+
+      - name: Build app before publishing
+        run: |
+          bun run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: dist
+
+  publish:
+    name: Publish to npm
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v3
+      name: Download build artifacts
+      with:
+        name: build-artifacts
+        path: dist
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Publish to npm
+      id: publish  # Assign an ID to this step
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Automated Version Bump
+      if: steps.publish.outcome == 'success'
+      uses: phips28/gh-action-bump-version@v11.0.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,17 @@
         "uiohook-napi": "^1.5.4"
       },
       "devDependencies": {
-        "@types/node": "^20.14.11",
-        "typescript": "^5.5.3"
+        "@types/node": "^22.1.0",
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
-      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
+      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.13.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
+      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uiohook-napi": "^1.5.4"
   },
   "devDependencies": {
-    "@types/node": "^20.14.11",
-    "typescript": "^5.5.3"
+    "@types/node": "^22.1.0",
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (.github/workflows/ci.yaml) to automate our CI/CD process. The workflow is designed to:

- Automatically trigger builds when changes are pushed to the main branch.
- Publish the built package to npmjs upon a successful build.

Key Changes you might want to tweak:
- I included a build step at the end to automatically bump the version number if the pushing is successful
you may want to remove this step if you don't like it
however, I find it helpful since npmjs requires the number to change with each release

To remove the "Automated Version Bump", just remove lines [43-45](https://github.com/QarthO/qHotkeys/pull/6/commits/0c71f8038c97af96629d472d8a19895a49b7e7e3#r1685764599) in `ci.yaml`