### PR TITLE
[publish] version to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,17 @@
         "uiohook-napi": "^1.5.4"
       },
       "devDependencies": {
-        "@types/node": "^22.1.0",
-        "typescript": "^5.5.4"
+        "@types/node": "^25.0.3",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qhotkeys",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Electron global shortcut registrar that doesn't override pre-existing shortcuts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uiohook-napi": "^1.5.4"
   },
   "devDependencies": {
-    "@types/node": "^22.1.0",
-    "typescript": "^5.5.4"
+    "@types/node": "^25.0.3",
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Updates project dependencies and bumps the version to `1.1.7`.

Resolves #10

### Reason for Change
The currently listed version on NPM (`1.1.6`) does not contain the latest compiled code (specifically the media keys support). The previous GitHub Action built the code but **skipped the publish step** because the commit message lacked the `[publish]` tag.

Since version `1.1.6` is already taken on the NPM registry, I have bumped the version to `1.1.7` to allow a fresh release.

### ⚠️ Important Merge Note
Your CI workflow is configured to only publish if the commit message starts with `[publish]`.

To ensure this release actually goes out to NPM:
* **If you Squash and Merge:** The PR title (`[publish] ...`) should automatically be used, so it should work fine.
* **If you do a standard Merge:** Please manually ensure the merge commit message starts with `[publish]`.